### PR TITLE
bugfix kube exists method

### DIFF
--- a/library/kube.py
+++ b/library/kube.py
@@ -218,7 +218,7 @@ class KubeManager(object):
             cmd.append('--all-namespaces')
 
         result = self._execute_nofail(cmd)
-        if not result or len(result) != 1:
+        if not result:
             return False
         return True
 


### PR DESCRIPTION
The exists method would check if the results were not a single
row and assume exists is false. For pod and service that could
be correct, but for an replicationController that is rarely the
case.

Removed the check to avoid false assumptions.
