### PR TITLE
Add load balancer for Openstack within terraform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM centos:7
+
+ENV TERRAFORM_VERSION 0.6.1
+ENV TERRAFORM_STATE_ROOT /state
+
+# install epel-release first otherwise installing pip or crypto will not be found
+RUN yum install -y epel-release openssl openssh-clients unzip && \
+    curl -SL -o /terraform.zip https://dl.bintray.com/mitchellh/terraform/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+    unzip /terraform.zip -d /usr/local/bin && \
+    rm -rf /terraform.zip && \
+    yum remove -y unzip && \
+    yum -y clean all && \
+    mkdir -p /state
+
+# install all dependencies
+COPY requirements.txt /kube/
+RUN yum install -y python-pip python-crypto && \
+    pip install -U -r /kube/requirements.txt && \
+    yum -y clean all
+
+# load kubernetes-ansible and default setup
+COPY . /kube/
+
+VOLUME /state /ssh
+
+WORKDIR /kube/
+CMD ["/kube/env_launch.sh"]

--- a/env_launch.sh
+++ b/env_launch.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+SSH_KEY=${SSH_KEY:-"/root/.ssh/id_rsa"}
+
+if [ ! -f "$SSH_KEY" ]; then
+    mkdir -p /root/.ssh/
+    find /ssh/* ! -type l -print0 | xargs -0 cp -t /root/.ssh/
+fi
+chown root:root /root/.ssh/*
+
+eval `ssh-agent -s` && ssh-add $SSH_KEY
+
+ansible-playbook playbooks/gen_lb_members.yml
+terraform get $TERRAFORM_STATE_ROOT
+terraform apply -state=$TERRAFORM_STATE_ROOT/terraform.tfstate -input=false $TERRAFORM_STATE_ROOT
+ansible-playbook playbooks/wait-for-hosts.yml --private-key $SSH_KEY
+ansible-playbook setup.yml --private-key $SSH_KEY

--- a/playbooks/gen_lb_members.yml
+++ b/playbooks/gen_lb_members.yml
@@ -1,0 +1,29 @@
+---
+
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: create fragments directory
+      file: path=/tmp/lb_member_fragments state=directory
+
+    - name: generate member replacement template fragments
+      template:
+        src: lb_members.j2
+        dest: "/tmp/lb_member_fragments/member-{{ item }}"
+      with_sequence: start=0 end={{ total_members-1 }}
+
+    - name: generate member replacement template
+      assemble: src=/tmp/lb_member_fragments dest=/tmp/lb_members
+
+    - name: set members for terraform lb
+      replace:
+        dest: "{{ lookup('env','TERRAFORM_STATE_ROOT') }}/terraform/openstack/hosts/main.tf"
+        regexp: '^  #%MEMBERS%$'
+        replace: "{{ lookup('file', '/tmp/lb_members') }}"
+
+    - name: clean up generated template file
+      file: path=/tmp/lb_members state=absent
+
+    - name: clean up generated fragments
+      file: path=/tmp/lb_member_fragments state=absent
+

--- a/playbooks/lb_members.j2
+++ b/playbooks/lb_members.j2
@@ -1,0 +1,6 @@
+  member {
+    address = "${ openstack_compute_instance_v2.resource.{{ item }}.access_ip_v4 }"
+    port = 443
+    admin_state_up = "true"
+  }
+

--- a/playbooks/wait-for-hosts.yml
+++ b/playbooks/wait-for-hosts.yml
@@ -1,0 +1,9 @@
+- hosts: all
+  gather_facts: no
+  tasks:
+    - name: wait for ssh to become available
+      local_action: wait_for
+                    port=22
+                    host="{{ ansible_ssh_host | default(inventory_hostname) }}"
+                    search_regex=OpenSSH
+                    delay=10

--- a/terraform/openstack.sample.tf
+++ b/terraform/openstack.sample.tf
@@ -27,6 +27,8 @@ module "dc2-hosts" {
     control_flavor_name = ""
     resource_flavor_name  = ""
     net_id = ""
+    subnet_id = ""
+    floating_pool = ""
     image_name = ""
     keypair_name = "${ module.dc2-keypair.keypair_name }"
     security_groups = "${ module.dc2-secgroup.cluster_name }"

--- a/terraform/openstack/hosts/main.tf
+++ b/terraform/openstack/hosts/main.tf
@@ -7,11 +7,13 @@ variable long_name { default = "kubernetes-on-openstack" }
 variable control_flavor_name { }
 variable resource_flavor_name { }
 variable net_id { }
+variable subnet_id { }
 variable keypair_name { }
 variable image_name { }
 variable control_count {}
 variable resource_count {}
 variable security_groups {}
+variable floating_pool { }
 
 provider "openstack" {
   auth_url = "${ var.auth_url }"
@@ -48,3 +50,33 @@ resource "openstack_compute_instance_v2" "resource" {
   count = "${ var.resource_count }"
 }
 
+resource "openstack_compute_floatingip_v2" "lb_fip" {
+  pool = "${ var.floating_pool }"
+}
+
+resource "openstack_lb_monitor_v1" "lb_monitor" {
+  type = "PING"
+  delay = 30
+  timeout = 5
+  max_retries = 3
+  admin_state_up = "true"
+}
+
+resource "openstack_lb_pool_v1" "lb_pool" {
+  name = "${ var.short_name }-pool"
+  protocol = "HTTPS"
+  subnet_id = "${ var.subnet_id }"
+  lb_method = "ROUND_ROBIN"
+  monitor_ids = ["${ openstack_lb_monitor_v1.lb_monitor.id }"]
+  #%MEMBERS%
+
+}
+
+resource "openstack_lb_vip_v1" "lb_vip" {
+  name = "${ var.short_name }-pool-vip"
+  subnet_id = "${ var.subnet_id }"
+  floating_ip = "${ openstack_compute_floatingip_v2.lb_fip.address }"
+  protocol = "HTTPS"
+  port = 443
+  pool_id = "${ openstack_lb_pool_v1.lb_pool.id }"
+}


### PR DESCRIPTION
Add Dockerfile that provides environment for using kubernetes-ansible
from any machine that has Docker installed.

I was not able to find a way to have all the worker nodes automatically added using terraform natively, so there is a small playbook that will generate it based on the number of worker nodes specified. (It is a bit of a hack but it was a close to automated as I could get.)

In my project I have environment specific variable files that contain a value for `total_members` which should match the number found within the terraform-openstack.tf  file.
