### PR TITLE
Creates Security Group with terraform

### DIFF
--- a/terraform/openstack-floating.sample.tf
+++ b/terraform/openstack-floating.sample.tf
@@ -7,6 +7,11 @@ module "dc2-keypair" {
   keypair_name = ""
 }
 
+module "dc2-secgroup" {
+    source = "./terraform/openstack/secgroup"
+    cluster_name = "k8s-cluster"
+}
+
 module "dc2-hosts-floating" {
   source = "./terraform/openstack/hosts-floating"
   auth_url = ""
@@ -17,6 +22,7 @@ module "dc2-hosts-floating" {
   node_flavor = ""
   image_name = ""
   keypair_name = "${ module.dc2-keypair.keypair_name }"
+  security_groups = "${ module.dc2-secgroup.cluster_name }"
   master_count = 1
   node_count = 2
   floating_pool = ""

--- a/terraform/openstack.sample.tf
+++ b/terraform/openstack.sample.tf
@@ -7,6 +7,11 @@ module "dc2-keypair" {
   keypair_name = ""
 }
 
+module "dc2-secgroup" {
+    source = "./terraform/openstack/secgroup"
+    cluster_name = "k8s-cluster"
+}
+
 module "dc2-hosts" {
   source = "./terraform/openstack/hosts"
   auth_url = ""
@@ -20,6 +25,6 @@ module "dc2-hosts" {
   keypair_name = "${ module.dc2-keypair.keypair_name }"
   master_count = 1
   node_count = 2
-  security_groups = ""
+  security_groups = "${ module.dc2-secgroup.cluster_name }"
   glusterfs_volume_size = 100
 }

--- a/terraform/openstack/hosts-floating/main.tf
+++ b/terraform/openstack/hosts-floating/main.tf
@@ -8,7 +8,7 @@ variable keypair_name { }
 variable image_name { }
 variable master_count {}
 variable node_count {}
-variable security_groups { default = "default" }
+variable security_groups {  }
 variable floating_pool {}
 variable external_net_id { }
 variable subnet_cidr { default = "10.10.10.0/24" }
@@ -29,7 +29,7 @@ resource "openstack_compute_instance_v2" "master" {
   key_pair              = "${ var.keypair_name }"
   image_name            = "${ var.image_name }"
   flavor_name           = "${ var.master_flavor }"
-  security_groups       = [ "${ var.security_groups }" ]
+  security_groups       = [ "${ var.security_groups }", "default" ]
   network               = { uuid = "${ openstack_networking_network_v2.ms-network.id }" }
   metadata              = {
                             dc = "${var.datacenter}"
@@ -45,7 +45,7 @@ resource "openstack_compute_instance_v2" "node" {
   key_pair              = "${ var.keypair_name }"
   image_name            = "${ var.image_name }"
   flavor_name           = "${ var.node_flavor }"
-  security_groups       = [ "${ var.security_groups }" ]
+  security_groups       = [ "${ var.security_groups }", "default" ]
   network               = { uuid = "${ openstack_networking_network_v2.ms-network.id }" }
   metadata              = {
                             dc = "${var.datacenter}"

--- a/terraform/openstack/hosts/main.tf
+++ b/terraform/openstack/hosts/main.tf
@@ -9,7 +9,7 @@ variable long_name { default = "kubernetes" }
 variable net_id { }
 variable node_count {}
 variable node_flavor { }
-variable security_groups { default = "default" }
+variable security_groups {  }
 variable short_name { default = "k8s" }
 variable ssh_user { default = "centos" }
 variable tenant_id { }
@@ -36,7 +36,7 @@ resource "openstack_compute_instance_v2" "master" {
   key_pair = "${ var.keypair_name }"
   image_name = "${ var.image_name }"
   flavor_name = "${ var.master_flavor }"
-  security_groups = [ "${ var.security_groups }" ]
+  security_groups = [ "${ var.security_groups }", "default" ]
   network = { uuid  = "${ var.net_id }" }
   volume = {
     volume_id = "${element(openstack_blockstorage_volume_v1.k8s-glusterfs.*.id, count.index)}"
@@ -55,7 +55,7 @@ resource "openstack_compute_instance_v2" "node" {
   key_pair = "${ var.keypair_name }"
   image_name = "${ var.image_name }"
   flavor_name = "${ var.node_flavor }"
-  security_groups = [ "${ var.security_groups }" ]
+  security_groups = [ "${ var.security_groups }", "default" ]
   network = { uuid = "${ var.net_id }" }
   metadata = {
     dc = "${var.datacenter}"

--- a/terraform/openstack/secgroup/main.tf
+++ b/terraform/openstack/secgroup/main.tf
@@ -1,0 +1,37 @@
+variable cluster_name { }
+variable auth_url { }
+variable tenant_id { }
+variable tenant_name { }
+
+provider "openstack" {
+    auth_url = "${ var.auth_url }"
+    tenant_id = "${ var.tenant_id }"
+    tenant_name = "${ var.tenant_name }"
+}
+
+resource "openstack_compute_secgroup_v2" "cluster" {
+    name = "${ var.cluster_name }"
+    description = "Security Group for ${ var.cluster_name }"
+    rule {
+        from_port = 1
+        to_port = 65535
+        ip_protocol = "tcp"
+        self = true
+    }
+    rule {
+        from_port = 1
+        to_port = 65535
+        ip_protocol = "udp"
+        self = true
+    }
+    rule {
+        from_port = 443
+        to_port = 443
+        ip_protocol = "tcp"
+        cidr = "0.0.0.0/0"
+    }
+}
+
+output "cluster_name" {
+    value = "${ openstack_compute_secgroup_v2.cluster.name }"
+}


### PR DESCRIPTION
Add security group resource that exposes all ports within the cluster,
and exposes the master port externally for incoming requests.

Also assumes the default security group which provides SSH access to
the hosts as well.

Changes applied to both openstack and openstack-floatingip.

closes: #29
