### PR TITLE
[TASK] Flannel install by mode

### DIFF
--- a/roles/flannel/tasks/main.yml
+++ b/roles/flannel/tasks/main.yml
@@ -8,13 +8,11 @@
   tags:
     - flannel
 
-- name: install flannel
-  sudo: yes
-  yum:
-    pkg="flannel-{{ flannel_version }}"
-    state=present
-  tags:
-    - flannel
+- include: stable.yml
+  when: kube_build == "stable"
+
+- include: testing.yml
+  when: kube_build == "testing"
 
 - name: install flannel sysconfig file
   sudo: yes

--- a/roles/flannel/tasks/stable.yml
+++ b/roles/flannel/tasks/stable.yml
@@ -1,0 +1,9 @@
+---
+- name: install flannel
+  sudo: yes
+  yum:
+    pkg="flannel-{{ flannel_version }}"
+    state=present
+  tags:
+    - flannel
+

--- a/roles/flannel/tasks/testing.yml
+++ b/roles/flannel/tasks/testing.yml
@@ -1,0 +1,10 @@
+---
+- name: install latest flannel
+  sudo: yes
+  yum:
+    pkg=flannel
+    state=latest
+    enablerepo=virt7-docker-common-candidate
+  tags:
+    - flannel
+


### PR DESCRIPTION
Previously flannel came from the virt7-docker-common-candidate repo
but after the last change it is no longer pulled from there.
To follow the same path as kubernetes, the install has been updated
to operate based on install modes (stable vs. testing).
