### PR TITLE
Added multithreading support for Serverspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 /*.tfvars
 **/*.syncdir
 /.bundle
+/serverspec_results.json
 /vendor

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
 --color
---format <%= ENV['FORMAT'] || 'documentation' %>
+--format <%= ENV['FORMAT'] || 'json' %>

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ The following command will append the hosts to your `/etc/hosts` file.
 ```
 
 
-### Validate ansible playbooks
+### Validate Ansible playbooks
 
 Install [Serverspec](http://serverspec.org) environment :
 
@@ -172,12 +172,18 @@ Install [Serverspec](http://serverspec.org) environment :
 bundle install --path vendor/bundle
 ```
 
-Run Serverspec tests for different plays :
+Run Serverspec test for all nodes and specs in parallel (using 8 threads), print *short* summary in JSON format and provide `0` exit code for succeed validation of Ansible playbooks :
 
 ```
-bundle exec rake check:play:All
-bundle exec rake check:play:Master
-bundle exec rake check:play:Node
+bundle exec rake -m -j 8
+```
+
+Run Serverspec tests for different plays in parallel :
+
+```
+bundle exec rake spec:play:All -m -j 8
+bundle exec rake spec:play:Master -m -j 8
+bundle exec rake spec:play:Node -m -j 8
 ```
 
 Show all available Rake-tasks :
@@ -186,12 +192,90 @@ Show all available Rake-tasks :
 bundle exec rake -T
 ```
 
-To use different [RSpec output formats](http://www.rubydoc.info/gems/rspec-core/RSpec/Core/Formatters) (`documentation` is default one) :
+To use different [RSpec output formats](http://www.rubydoc.info/gems/rspec-core/RSpec/Core/Formatters) (`json` is default one) :
 
 ```
-FORMAT=documentation bundle exec rake check:play:All
-FORMAT=json bundle exec rake check:play:All
-FORMAT=progress bundle exec rake check:play:All
+FORMAT=documentation bundle exec rake spec:play:All -m -j 8
+FORMAT=json bundle exec rake spec:play:All -m -j 8
+FORMAT=progress bundle exec rake spec:play:All -m -j 8
+```
+
+##### JSON output format
+
+When using `FORMAT=json` (default) the output will contain tests *summary* only :
+
+```json
+{
+  "succeed": true,
+  "example_count": 490,
+  "failure_count": 0
+}
+```
+
+*Detailed* results could be found inside `serverspec_results.json` file at project root directory :
+
+```json
+[
+  {
+    "name": "docker::k-master-01",
+    "exit_code": 0,
+    "output": {
+      "version": "3.4.0",
+      "examples": [
+        {
+          "description": "should be installed",
+          "full_description": "docker : Main | Package \"docker\" should be installed",
+          "status": "passed",
+          "file_path": "./roles/docker/spec/main_spec.rb",
+          "line_number": 5,
+          "run_time": 3.202775,
+          "pending_message": null
+        },
+        {
+          "description": "should be enabled",
+          "full_description": "docker : Main | Service \"docker\" should be enabled",
+          "status": "passed",
+          "file_path": "./roles/docker/spec/main_spec.rb",
+          "line_number": 9,
+          "run_time": 0.443939,
+          "pending_message": null
+        }
+      ],
+      "summary": {
+        "duration": 4.07774,
+        "example_count": 3,
+        "failure_count": 0,
+        "pending_count": 0
+      },
+      "summary_line": "3 examples, 0 failures"
+    }
+  },
+  {
+    "name": "flannel::k-master-01",
+    "exit_code": 0,
+    "output": {
+      "version": "3.4.0",
+      "examples": [
+        {
+          "description": "should be installed",
+          "full_description": "flannel : Main |  Service | Package \"flannel\" should be installed",
+          "status": "passed",
+          "file_path": "./roles/flannel/spec/main_spec.rb",
+          "line_number": 6,
+          "run_time": 3.253822,
+          "pending_message": null
+        }
+      ],
+      "summary": {
+        "duration": 6.399068,
+        "example_count": 10,
+        "failure_count": 0,
+        "pending_count": 0
+      },
+      "summary_line": "10 examples, 0 failures"
+    }
+  }
+]
 ```
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -7,16 +7,38 @@ require 'json'
 require 'yaml'
 
 
+# set JSON format as default one
+ENV['FORMAT'] ||= 'json'
+
+$results = []
+
+
 class ServerspecTask < RSpec::Core::RakeTask
 
-  attr_accessor :hosts
+  attr_accessor :target_host
+  attr_accessor :target_host_vars
+  attr_accessor :target_play_role
 
   def run_task(verbose)
-    hosts.each_pair do |hostname, vars|
-      puts "Running tests on #{hostname} [#{vars['ansible_ssh_host']}]"
+    command = "TARGET_HOST=#{target_host_vars['ansible_ssh_host']} "
+    command << "TARGET_HOST_NAME=#{target_host} "
+    command << "TARGET_PORT=#{target_host_vars['ansible_ssh_port']} "
+    command << "TARGET_USER=#{target_host_vars['ansible_ssh_user']} "
+    command << "#{spec_command}"
 
-      success = system("env TARGET_HOST=#{vars['ansible_ssh_host']} TARGET_HOST_NAME=#{hostname} TARGET_PORT=#{vars['ansible_ssh_port']} TARGET_USER=#{vars['ansible_ssh_user']} #{spec_command}")
-      raise "Failed!" if not success
+    if ENV['FORMAT'] == 'json'
+      output = `#{command}`
+
+      $results << {
+        :name => self.name,
+        :exit_code => $?.to_i,
+        :output => JSON.parse(output)
+      }
+    else
+      puts "Running \"#{target_play_role}\" tests on #{target_host} [#{target_host_vars['ansible_ssh_host']}]"
+
+      succeed = system "#{command}"
+      raise "Failed!" if not succeed
     end
   end
 end
@@ -28,21 +50,69 @@ inventory = JSON.parse `./plugins/inventory/terraform.py --list`
 hosts = inventory['_meta']['hostvars']
 
 
-namespace :check do
-  namespace :play do
-    playbook.each do |play|
-      checkable_hosts = hosts.select { |host|
-        play['hosts'] == 'all' or
-        play['hosts'].include? hosts[host]['role']
-      }
+namespace :spec do
+  all_tasks = []
 
-      desc "Run serverspec to play #{play['name']}"
-      ServerspecTask.new(play['name'].to_sym) do |t|
-        t.hosts = checkable_hosts
-        t.pattern = File.join('.', 'roles', '{' + play['roles'].join(",") + '}', 'spec', '*_spec.rb')
+  playbook.each do |play|
+    checkable_hosts = hosts.select { |host|
+      play['hosts'] == 'all' or
+      play['hosts'].include? hosts[host]['role']
+    }
+
+    play_tasks = []
+
+    play['roles'].each do |play_role|
+      checkable_hosts.each do |hostname, vars|
+        task_name = "#{play_role}::#{hostname}".to_sym
+
+        desc "Run serverspec for \"#{play_role}\" role at #{hostname}"
+        ServerspecTask.new(task_name) do |t|
+          t.target_host = hostname
+          t.target_host_vars = vars
+          t.target_play_role = play_role
+          t.pattern = File.join('.', 'roles', play_role, 'spec', '*_spec.rb')
+        end
+
+        play_tasks << task_name
+        all_tasks << task_name
       end
     end
+
+    namespace :play do
+      desc "Run serverspec to play \"#{play['name']}\""
+      task play['name'].to_sym => play_tasks
+    end
+  end
+
+  desc "Run all serverspecs at once"
+  task ':all' => all_tasks
+
+  task :aggregate_results do
+    summary = {
+      :succeed => true,
+      :example_count => 0,
+      :failure_count => 0
+    }
+
+    $results.each do |result|
+      summary[:succeed] &&= result[:exit_code] == 0
+      summary[:example_count] += result[:output]['summary']['example_count']
+      summary[:failure_count] += result[:output]['summary']['failure_count']
+    end
+
+
+    # save tonns of output to file
+    File.write File.join(__dir__, 'serverspec_results.json'), JSON.pretty_generate($results)
+
+    puts JSON.pretty_generate(summary)
+    exit 1 if not summary[:succeed]
   end
 end
 
-task :default => ['check:play:All']
+task :default => ['spec::all']
+
+
+# add JSON result aggregation as last task
+if ENV['FORMAT'] == 'json'
+  at_exit { Rake::Task['spec:aggregate_results'].invoke if $!.nil? }
+end


### PR DESCRIPTION
New Serverspec multithreading mode gives us up to **4.5x** performance boost when running tests : 

```
$ time rake -m -j 8
{
  "succeed": true,
  "example_count": 490,
  "failure_count": 0
}
rake -m -j 8  39% cpu 41.076 total

$ time rake
{
  "succeed": true,
  "example_count": 490,
  "failure_count": 0
}
rake  6% cpu 3:10.76 total
```

Plus JSON-outputs from different specs are now aggregated into short JSON-summary with proper exit codes and detailed JSON-file (`serverspec_results.json`).  
