### PR TITLE
add support for extra nameservers for specific domains

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -59,6 +59,13 @@ dns_setup: true
 # Number of replicas of DNS instances started on kubernetes
 dns_replicas: 1
 
+# specify extra upstream dns servers for specific domains
+#dns_extra:
+#  cisco.com:
+#    - 72.163.5.201
+#    - 64.102.255.44
+#    - 173.37.146.41
+
 # Set to 'false' to disable default Kubernetes UI setup
 enable_ui: true
 

--- a/roles/dnsmasq/templates/01-kube-dns.conf.j2
+++ b/roles/dnsmasq/templates/01-kube-dns.conf.j2
@@ -11,3 +11,12 @@ server=8.8.4.4
 
 # Forward k8s domain to kube-dns
 server=/{{ dns_domain }}/{{ dns_server }}
+
+{% if dns_extra is defined and dns_extra is iterable %}
+  {%- for key, val in dns_extra.iteritems() %}
+    {%- for nameserver in val %}
+
+server=/{{ key }}/{{ nameserver }}
+    {%- endfor %}
+  {%- endfor %}
+{% endif %}


### PR DESCRIPTION
Currently since dnsmasq is configured to the google dns only it is not able to resolve internal domains such as quay.cisco.com
