### PR TITLE
Kube v1.2.2

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -5,7 +5,7 @@
 package_channel: stable
 
 # The version of software to install for Kubernetes.
-kube_version: v1.1.3
+kube_version: v1.2.2
 
 # Users to create for basic auth in Kubernetes API via HTTP
 kube_users:

--- a/roles/kubernetes-master/templates/kube-controller-manager.yml
+++ b/roles/kubernetes-master/templates/kube-controller-manager.yml
@@ -14,6 +14,8 @@ spec:
     - --master=http://127.0.0.1:8080
     - --service-account-private-key-file={{ kube_cert_dir }}/server.key
     - --root-ca-file={{ kube_cert_dir }}/ca.crt
+    - --cloud-provider={{ cloud_provider if enable_cloud_provider else "" }}
+    - --cloud-config={{ cloud_provider_config if enable_cloud_provider else "" }}
     - --v={{kube_log_level}}
     livenessProbe:
       httpGet:

--- a/roles/kubernetes-master/templates/kubelet.service.j2
+++ b/roles/kubernetes-master/templates/kubelet.service.j2
@@ -7,7 +7,8 @@ Requires=docker.service
 [Service]
 ExecStart=/usr/bin/kubelet \
   --api-servers=http://localhost:8080 \
-  --register-node=false \
+  --register-node=true \
+  --register-schedulable=false \
   --hostname-override={{ inventory_hostname }} \
   --allow-privileged=true \
   --cluster-dns={{ dns_server }} \


### PR DESCRIPTION
Upgrade to kubernetes v.1.2.2. Also updated kubelet service to v1.2.2 compatible. 
Previously master node was not registered. After this upgrade it is (and can be monitored for example with kubectl describe node), but it's still unschedulable.
